### PR TITLE
feat: retain replaceable events with the lowest id 

### DIFF
--- a/src/nostr/repositories/event.repository.spec.ts
+++ b/src/nostr/repositories/event.repository.spec.ts
@@ -371,12 +371,6 @@ describe('EventRepository', () => {
         await eventRepository.findOne({ ids: [REPLACEABLE_EVENT.id] }),
       ).toBeNull();
     });
-
-    it('should return false when the id of the old and new events are the same', async () => {
-      expect(
-        await eventRepository.replace(REPLACEABLE_EVENT, REPLACEABLE_EVENT.id),
-      ).toBeFalsy();
-    });
   });
 
   describe('findTopIdsWithScore', () => {

--- a/src/nostr/repositories/event.repository.ts
+++ b/src/nostr/repositories/event.repository.ts
@@ -130,10 +130,6 @@ export class EventRepository {
   }
 
   async replace(event: Event, oldEventId?: string) {
-    if (event.id === oldEventId) {
-      return false;
-    }
-
     if (oldEventId) {
       await this.event.delete({ id: oldEventId });
     }

--- a/src/nostr/services/event.service.spec.ts
+++ b/src/nostr/services/event.service.spec.ts
@@ -125,6 +125,28 @@ describe('EventService', () => {
         expect(mockEmit).not.toBeCalled();
       });
 
+      it('should return duplicate when the event has the same timestamp but the ID is larger', async () => {
+        const eventRepository = createMock<EventRepository>({
+          findOne: async () =>
+            Event.fromEventDto({
+              ...REPLACEABLE_EVENT_DTO,
+              id: '0000000000000000000000000000000000000000000000000000000000000000',
+            }),
+          replace: async () => true,
+        });
+        (eventService as any).eventRepository = eventRepository;
+
+        await expect(
+          eventService.handleEvent(REPLACEABLE_EVENT),
+        ).resolves.toEqual(
+          createCommandResultResponse(
+            REPLACEABLE_EVENT.id,
+            true,
+            'duplicate: the event already exists',
+          ),
+        );
+      });
+
       it('should return rate-limited when acquiring the lock fails', async () => {
         (eventService as any).storageService = createMock<StorageService>({
           setNx: async () => false,


### PR DESCRIPTION
retain replaceable events with the lowest id when timestamps are the same

https://github.com/nostr-protocol/nips/blob/202e18f2b256646148805880ed58731c1c8b2b9b/01.md?plain=1#L89